### PR TITLE
Profile server

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('friends/', include('friends.urls')),
     path('profile/', views.profile, name='my_profile'),
     path('profile/<uuid:pk>', views.profile, name='profile'), # TODO: Change to <uuid:pk> when implemented
+    path('profile/<str:value>', views.profile, name='profile'), # TODO: Change to <uuid:pk> when implemented
     path('profile/follow/', friends.views.follow, name='follow'),
     path('profile/unfollow/', friends.views.unfollow, name='unfollow'),
     path('profile/edit/',views.edit_profile,name='edit_profile')

--- a/core/views.py
+++ b/core/views.py
@@ -202,49 +202,16 @@ def home(request):
 
 	return render(request, "home.html", context)
 
-@login_required(login_url='/login')
-def profile(request, pk = None):
-
-	if not request.user.is_authenticated:
-		return HttpResponseForbidden()
-
-
-	print (pk)
-	print ("ERE")
-	
-	# If no pk is provided, just default to the current user's page
-	if pk is None:
-		pk = request.user.id
-
-	try:
-		user = User.objects.get(pk=pk)
-	except ObjectDoesNotExist:
-		# TODO: Return a custom 404 page
-		return HttpResponseNotFound("That user does not exist")
-	print (user)
-	# Check if we follow the user whose profile we are looking at
-	following = False
-	button_text = "Unfollow"
-	if request.user.id is not pk:
-		following = follows(request.user.id, pk)
-		if (following == False):
-			button_text = "Follow"
-
-
-	return render(request, 'profile.html', {'user': user, 'following': following, 'button_text': button_text})
-
 
 def get_user(parameters):
 	user = User()
 	service, profile_id = parameters.split('+')
-
 	build_request = 'https://' + service+ '/service/author/'+profile_id
 	try:
 		r=requests.get(build_request)
 		response = r.json()
 	except:
-		return null
-
+		return HttpResponseNotFound("That user does not exist")
 	user.bio = response['bio']
 	user.username = response['displayName']
 	user.first_name = response['firstName']
@@ -258,7 +225,7 @@ def get_user(parameters):
 
 
 login_required(login_url='/login')
-def profile(request, value=None):
+def profile(request, value=None, pk=None):
 
 	if not request.user.is_authenticated:
 		return HttpResponseForbidden()
@@ -276,7 +243,7 @@ def profile(request, value=None):
 		following = follows(request.user.id, user.id)
 		if (following == False):
 			button_text = "Follow"
-	return render(request, 'profile.html', {'user': user, 'following': following, 'button_text': button_text})
+	return render(request, 'profile.html', {'user': user, 'following': following, 'button_text': button_text}) 
 
 
 @login_required(login_url='/login')

--- a/core/views.py
+++ b/core/views.py
@@ -230,10 +230,9 @@ def profile(request, value=None, pk=None):
 	if not request.user.is_authenticated:
 		return HttpResponseForbidden()
 	user = User()
-
 	# If no value, then we know we are looking at 'my_profile'
 	if value is None:
-		pk = request.user.id
+		pk = pk if pk is not None else request.user.id
 		user = User.objects.get(pk=pk)
 	else:
 		user = get_user(value)

--- a/posts/views.py
+++ b/posts/views.py
@@ -68,6 +68,7 @@ def posts_detail(request, id):
             print("comment worked.")
 
     comments = instance.comments
+
     context = {
         "user": instance.user,
         "instance": instance,


### PR DESCRIPTION
Pulls in profiles from other servers:
As the only way to find other server profiles is through posts, I'm suggesting we make all names on posts/comments as links to profile page. That means we need to pull in the author uuid - which we still need to build out. So - this is built on the assumption that we can do that, and then also pull in the server name. 

So a profile page from another server would be:
https://cmput404-wave.herokuapp.com/home/profile/obscure-lake-45818.herokuapp.com+f90a0512-fffe-42b0-bc8f-043b5c006ca7
